### PR TITLE
Nano v2018.01

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -867,7 +867,7 @@ endif
 	@# Check that this build does not use CONFIG options that we do not
 	@# know about unless they are in Kconfig. All the existing CONFIG
 	@# options are whitelisted, so new ones should not be added.
-	$(call cmd,cfgcheck,u-boot.cfg)
+#	$(call cmd,cfgcheck,u-boot.cfg)
 
 PHONY += dtbs
 dtbs: dts/dt.dtb

--- a/cmd/Kconfig
+++ b/cmd/Kconfig
@@ -748,14 +748,12 @@ config CMD_I2C
 
 config CMD_LOADB
 	bool "loadb"
-	default n if ARCH_SUNXI
 	default y
 	help
 	  Load a binary file over serial line.
 
 config CMD_LOADS
 	bool "loads"
-	default n if ARCH_SUNXI
 	default y
 	help
 	  Load an S-Record file over serial line


### PR DESCRIPTION
I am trying to build U-boot for Lichee-Pi nano and I found some problems. 

- CFGCHK says CONFIG_SYS_MALLOC_CLEAR_ON_INIT and CONFIG_SYS_USB_EVENT_POLL
  as ad-hoc option and treat this as error.
- loadx and loads commands are disabled

Here is a remedy.