### PR TITLE
Fix errors during shrink uboot size.

### DIFF
--- a/arch/arm/dts/sunxi-u-boot.dtsi
+++ b/arch/arm/dts/sunxi-u-boot.dtsi
@@ -7,7 +7,11 @@
  * blocks, but devices using something other than that remains to be
  * seen.
  */
+#ifdef CONFIG_ENV_OFFSET
 #define UBOOT_MMC_MAX_SIZE	(CONFIG_ENV_OFFSET - (CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_SECTOR * 512))
+#else
+#define UBOOT_MMC_MAX_SIZE 0xf0000
+#endif
 
 / {
 	binman {

--- a/board/sunxi/board.c
+++ b/board/sunxi/board.c
@@ -674,7 +674,7 @@ static void setup_environment(const void *fdt)
 		/* Ensure the NIC specific bytes of the mac are not all 0 */
 		if ((sid[3] & 0xffffff) == 0)
 			sid[3] |= 0x800000;
-
+#ifdef CONFIG_CMD_NET
 		for (i = 0; i < 4; i++) {
 			sprintf(ethaddr, "ethernet%d", i);
 			if (!fdt_get_alias(fdt, ethaddr))
@@ -698,7 +698,7 @@ static void setup_environment(const void *fdt)
 
 			eth_env_set_enetaddr(ethaddr, mac_addr);
 		}
-
+#endif
 		if (!env_get("serial#")) {
 			snprintf(serial_string, sizeof(serial_string),
 				"%08x%08x", sid[0], sid[3]);

--- a/include/configs/sunxi-common.h
+++ b/include/configs/sunxi-common.h
@@ -450,6 +450,18 @@ extern int soft_i2c_gpio_scl;
 #define BOOT_TARGET_DEVICES_USB(func)
 #endif
 
+#if defined(CONFIG_CMD_PXE) && defined(CONFIG_NET)
+#define BOOT_TARGET_DEVICES_PXE(func) func(PXE, pxe, na)
+#else
+#define BOOT_TARGET_DEVICES_PXE(func)
+#endif
+
+#if defined(CONFIG_CMD_DHCP) && defined(CONFIG_NET)
+#define BOOT_TARGET_DEVICES_DHCP(func) func(DHCP, dhcp, na)
+#else
+#define BOOT_TARGET_DEVICES_DHCP(func)
+#endif
+
 /* FEL boot support, auto-execute boot.scr if a script address was provided */
 #define BOOTENV_DEV_FEL(devtypeu, devtypel, instance) \
 	"bootcmd_fel=" \
@@ -465,8 +477,8 @@ extern int soft_i2c_gpio_scl;
 	BOOT_TARGET_DEVICES_MMC(func) \
 	BOOT_TARGET_DEVICES_SCSI(func) \
 	BOOT_TARGET_DEVICES_USB(func) \
-	func(PXE, pxe, na) \
-	func(DHCP, dhcp, na)
+	BOOT_TARGET_DEVICES_PXE(func) \
+	BOOT_TARGET_DEVICES_DHCP(func)
 
 #ifdef CONFIG_OLD_SUNXI_KERNEL_COMPAT
 #define BOOTCMD_SUNXI_COMPAT \


### PR DESCRIPTION
With this patch and proper .config file, I can shrink the uboot-spl+uboot size to 192kb.